### PR TITLE
fix: external link cannot be accessed when the endpoint is prefixed with http and  upload failed when the save location prefix is "/"

### DIFF
--- a/src/main/java/run/halo/alioss/AliOssAttachmentHandler.java
+++ b/src/main/java/run/halo/alioss/AliOssAttachmentHandler.java
@@ -4,6 +4,9 @@ import com.aliyun.oss.ClientException;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
 import com.aliyun.oss.OSSException;
+import com.aliyun.oss.common.auth.DefaultCredentialProvider;
+import com.aliyun.oss.common.comm.Protocol;
+import com.aliyun.oss.ClientBuilderConfiguration;
 import com.aliyun.oss.internal.OSSHeaders;
 import com.aliyun.oss.model.CannedAccessControlList;
 import com.aliyun.oss.model.ObjectMetadata;
@@ -131,8 +134,14 @@ public class AliOssAttachmentHandler implements AttachmentHandler {
     }
 
     OSS buildOss(AliOssProperties properties) {
-        return new OSSClientBuilder().build(properties.getEndpoint(), properties.getAccessKey(),
-            properties.getAccessSecret());
+        var config = new ClientBuilderConfiguration();
+        config.setProtocol(Protocol.HTTPS);
+        return OSSClientBuilder.create()
+                .endpoint(properties.getEndpoint())
+                .credentialsProvider(new DefaultCredentialProvider(properties.getAccessKey(),
+                        properties.getAccessSecret()))
+                .clientConfiguration(config)
+                .build();
     }
 
     Mono<ObjectDetail> upload(UploadContext uploadContext, AliOssProperties properties) {

--- a/src/main/java/run/halo/alioss/AliOssProperties.java
+++ b/src/main/java/run/halo/alioss/AliOssProperties.java
@@ -41,4 +41,19 @@ class AliOssProperties {
     public void setEndpoint(String endpoint) {
         this.endpoint = UrlUtils.removeHttpPrefix(endpoint);
     }
+
+    public void setLocation(String location) {
+        final var fileSeparator = "/";
+        if (StringUtils.hasText(location)) {
+            if (location.startsWith(fileSeparator)) {
+                location = location.substring(1);
+            }
+            if (location.endsWith(fileSeparator)) {
+                location = location.substring(0, location.length() - 1);
+            }
+        } else {
+            location = "";
+        }
+        this.location = location;
+    }
 }

--- a/src/main/java/run/halo/alioss/AliOssProperties.java
+++ b/src/main/java/run/halo/alioss/AliOssProperties.java
@@ -35,13 +35,10 @@ class AliOssProperties {
     }
 
     public void setDomain(String domain) {
-        if (domain != null){
-            if (domain.toLowerCase().startsWith("http://")){
-                domain = domain.substring(7);
-            } else if (domain.toLowerCase().startsWith("https://")) {
-                domain = domain.substring(8);
-            }
-        }
-        this.domain = domain;
+        this.domain = UrlUtils.removeHttpPrefix(domain);
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = UrlUtils.removeHttpPrefix(endpoint);
     }
 }

--- a/src/main/java/run/halo/alioss/UrlUtils.java
+++ b/src/main/java/run/halo/alioss/UrlUtils.java
@@ -1,0 +1,20 @@
+package run.halo.alioss;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UrlUtils {
+    private static final List<String> HTTP_PREFIXES = Arrays.asList("http://", "https://");
+
+    public static String removeHttpPrefix(String url) {
+        if (url != null) {
+            for (var httpPrefix : HTTP_PREFIXES) {
+                if (url.toLowerCase().startsWith(httpPrefix)) {
+                    url = url.substring(httpPrefix.length());
+                    break;
+                }
+            }
+        }
+        return url;
+    }
+}

--- a/src/test/java/run/halo/alioss/UrlUtilsTest.java
+++ b/src/test/java/run/halo/alioss/UrlUtilsTest.java
@@ -1,0 +1,15 @@
+package run.halo.alioss;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UrlUtilsTest {
+
+    @Test
+    void testRemoveHttpPrefix() {
+        assert UrlUtils.removeHttpPrefix(null) == null;
+        assert UrlUtils.removeHttpPrefix("http://www.example.com").equals("www.example.com");
+        assert UrlUtils.removeHttpPrefix("https://www.example.com").equals("www.example.com");
+    }
+}


### PR DESCRIPTION
Fixed https://github.com/halo-sigs/plugin-alioss/issues/5

## Endpoint 带上http协议头导致无法正常显示图片
原因：拼接链接时会把协议头拼接成链接的一部分，导致不正确
措施：在setter中去除http协议头
测试：endpoint中带上http协议头，上传文件后外链仍能正常访问

## 上传目录设置项以`/`开头会导致上传失败
原因：阿里oss会拒绝以`/`开头的objectKey
措施：在setter中去除前后的`/`
测试：上传目录中填写以`/`开头的目录，能上传成功