### PR TITLE
feat: check file exists and auto rename attachment if it exists

### DIFF
--- a/src/main/java/run/halo/alioss/AliOssAttachmentHandler.java
+++ b/src/main/java/run/halo/alioss/AliOssAttachmentHandler.java
@@ -14,21 +14,27 @@ import com.aliyun.oss.model.PutObjectRequest;
 import com.aliyun.oss.model.PutObjectResult;
 import com.aliyun.oss.model.StorageClass;
 import com.aliyun.oss.model.VoidResult;
+
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Extension;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebInputException;
 import org.springframework.web.util.UriUtils;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
 import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.extension.attachment.Attachment.AttachmentSpec;
 import run.halo.app.core.extension.attachment.Constant;
@@ -43,6 +49,7 @@ import run.halo.app.infra.utils.JsonUtils;
 public class AliOssAttachmentHandler implements AttachmentHandler {
 
     private static final String OBJECT_KEY = "alioss.plugin.halo.run/object-key";
+    private final Map<String, Object> uploadingFile = new ConcurrentHashMap<>();
 
     @Override
     public Mono<Attachment> upload(UploadContext uploadContext) {
@@ -50,7 +57,7 @@ public class AliOssAttachmentHandler implements AttachmentHandler {
             .flatMap(context -> {
                 final var properties = getProperties(context.configMap());
                 return upload(context, properties).map(
-                    objectDetail -> this.buildAttachment(context, properties, objectDetail));
+                    objectDetail -> this.buildAttachment(properties, objectDetail));
             });
     }
 
@@ -108,23 +115,22 @@ public class AliOssAttachmentHandler implements AttachmentHandler {
         return JsonUtils.jsonToObject(settingJson, AliOssProperties.class);
     }
 
-    Attachment buildAttachment(UploadContext uploadContext, AliOssProperties properties,
-                               ObjectDetail objectDetail) {
+    Attachment buildAttachment(AliOssProperties properties, ObjectDetail objectDetail) {
         var host = properties.getBucket() + "." + properties.getEndpoint();
         var externalLink = properties.getProtocol() + "://" +
                 (StringUtils.hasText(properties.getDomain()) ? properties.getDomain() : host) +
-                "/" + objectDetail.objectName();
+                "/" + objectDetail.objectKey();
 
         var metadata = new Metadata();
         metadata.setName(UUID.randomUUID().toString());
         metadata.setAnnotations(
-            Map.of(OBJECT_KEY, objectDetail.objectName(), Constant.EXTERNAL_LINK_ANNO_KEY,
+            Map.of(OBJECT_KEY, objectDetail.objectKey(), Constant.EXTERNAL_LINK_ANNO_KEY,
                 UriUtils.encodePath(externalLink, StandardCharsets.UTF_8)));
 
         var objectMetadata = objectDetail.objectMetadata();
         var spec = new AttachmentSpec();
         spec.setSize(objectMetadata.getContentLength());
-        spec.setDisplayName(uploadContext.file().filename());
+        spec.setDisplayName(objectDetail.fileName());
         spec.setMediaType(objectMetadata.getContentType());
 
         var attachment = new Attachment();
@@ -145,42 +151,89 @@ public class AliOssAttachmentHandler implements AttachmentHandler {
     }
 
     Mono<ObjectDetail> upload(UploadContext uploadContext, AliOssProperties properties) {
-        return Mono.fromCallable(() -> {
-            var client = buildOss(properties);
-            // build object name
-            var objectName = properties.getObjectName(uploadContext.file().filename());
+        return Mono.zip(Mono.just(buildOss(properties)),
+                        Mono.just(new FileNameHolder(uploadContext.file().filename(), properties)))
+                .flatMap(tuple -> {
+                    var client = tuple.getT1();
+                    var fileNameHolder = tuple.getT2();
+                    return checkFileExistsAndRename(client, fileNameHolder)
+                            .map(holder -> {
+                                var pos = new PipedOutputStream();
+                                PipedInputStream pis;
+                                try {
+                                    pis = new PipedInputStream(pos);
+                                } catch (IOException e) {
+                                    throw Exceptions.propagate(e);
+                                }
+                                DataBufferUtils.write(uploadContext.file().content(), pos)
+                                        .subscribeOn(Schedulers.boundedElastic()).doOnComplete(() -> {
+                                            try {
+                                                pos.close();
+                                            } catch (IOException ioe) {
+                                                // close the stream quietly
+                                                log.warn("Failed to close output stream", ioe);
+                                            }
+                                        }).subscribe(DataBufferUtils.releaseConsumer());
 
-            var pos = new PipedOutputStream();
-            var pis = new PipedInputStream(pos);
-            DataBufferUtils.write(uploadContext.file().content(), pos)
-                .subscribeOn(Schedulers.boundedElastic()).doOnComplete(() -> {
-                    try {
-                        pos.close();
-                    } catch (IOException ioe) {
-                        // close the stream quietly
-                        log.warn("Failed to close output stream", ioe);
+                                final var bucket = properties.getBucket();
+                                log.info("Uploading {} into AliOSS {}/{}/{}", uploadContext.file().filename(),
+                                        properties.getEndpoint(), bucket, holder.objectKey);
+
+                                var request = new PutObjectRequest(bucket, holder.objectKey, pis);
+                                var metadata = new ObjectMetadata();
+                                metadata.setHeader(OSSHeaders.OSS_STORAGE_CLASS, StorageClass.Standard.toString());
+                                metadata.setObjectAcl(CannedAccessControlList.PublicRead);
+                                request.setMetadata(metadata);
+
+                                return ossExecute(() -> {
+                                    var result = client.putObject(request);
+                                    if (log.isDebugEnabled()) {
+                                        debug(result);
+                                    }
+                                    var objectMetadata = client.getObjectMetadata(bucket, holder.objectKey);
+                                    return new ObjectDetail(bucket, holder.objectKey, objectMetadata, holder.fileName);
+                                }, null);
+                            })
+                            .doFinally(signalType -> {
+                                if (fileNameHolder.needRemoveMapKey) {
+                                    uploadingFile.remove(fileNameHolder.getUploadingMapKey());
+                                }
+                                client.shutdown();
+                            });
+                });
+    }
+
+    private Mono<FileNameHolder> checkFileExistsAndRename(OSS client, FileNameHolder fileNameHolder) {
+        return Mono.defer(() -> {
+                    // deduplication of uploading files
+                    if (uploadingFile.put(fileNameHolder.getUploadingMapKey(),
+                            fileNameHolder.getUploadingMapKey()) != null) {
+                        return Mono.error(new FileAlreadyExistsException("文件 " + fileNameHolder.objectKey
+                                + " 已存在，建议更名后重试。[local]"));
                     }
-                }).subscribe(DataBufferUtils.releaseConsumer());
-
-            final var bucket = properties.getBucket();
-            log.info("Uploading {} into AliOSS {}/{}/{}", uploadContext.file().filename(),
-                properties.getEndpoint(), bucket, objectName);
-
-            var request = new PutObjectRequest(bucket, objectName, pis);
-            var metadata = new ObjectMetadata();
-            metadata.setHeader(OSSHeaders.OSS_STORAGE_CLASS, StorageClass.Standard.toString());
-            metadata.setObjectAcl(CannedAccessControlList.PublicRead);
-            request.setMetadata(metadata);
-
-            return ossExecute(() -> {
-                var result = client.putObject(request);
-                if (log.isDebugEnabled()) {
-                    debug(result);
-                }
-                var objectMetadata = client.getObjectMetadata(bucket, objectName);
-                return new ObjectDetail(bucket, objectName, objectMetadata);
-            }, client::shutdown);
-        }).subscribeOn(Schedulers.boundedElastic());
+                    fileNameHolder.needRemoveMapKey = true;
+                    // check whether file exists
+                    boolean exist = ossExecute(() -> client.doesObjectExist(fileNameHolder.properties.getBucket(),
+                                    fileNameHolder.objectKey),
+                            null);
+                    if (exist) {
+                        return Mono.error(new FileAlreadyExistsException("文件 " + fileNameHolder.objectKey
+                                + " 已存在，建议更名后重试。[remote]"));
+                    }
+                    return Mono.just(fileNameHolder);
+                })
+                .retryWhen(Retry.max(3)
+                        .filter(FileAlreadyExistsException.class::isInstance)
+                        .doAfterRetry(retrySignal -> {
+                            if (fileNameHolder.needRemoveMapKey) {
+                                uploadingFile.remove(fileNameHolder.getUploadingMapKey());
+                                fileNameHolder.needRemoveMapKey = false;
+                            }
+                            fileNameHolder.randomFileName();
+                        })
+                )
+                .onErrorMap(Exceptions::isRetryExhausted,
+                        throwable -> new ServerWebInputException(throwable.getCause().getMessage()));
     }
 
     void debug(PutObjectResult result) {
@@ -210,7 +263,31 @@ public class AliOssAttachmentHandler implements AttachmentHandler {
         return "alioss".equals(templateName);
     }
 
-    record ObjectDetail(String bucketName, String objectName, ObjectMetadata objectMetadata) {
+    record ObjectDetail(String bucketName, String objectKey, ObjectMetadata objectMetadata, String fileName) {
+    }
+
+    static class FileNameHolder {
+        final AliOssProperties properties;
+        final String originalFileName;
+        String fileName;
+        String objectKey;
+        boolean needRemoveMapKey = false;
+
+        FileNameHolder(String fileName, AliOssProperties properties) {
+            this.fileName = fileName;
+            this.objectKey = properties.getObjectName(fileName);
+            this.originalFileName = fileName;
+            this.properties = properties;
+        }
+
+        public String getUploadingMapKey() {
+            return properties.getBucket() + "/" + objectKey;
+        }
+
+        public void randomFileName() {
+            this.fileName = FileNameUtils.randomFileName(originalFileName, 4);
+            this.objectKey = properties.getObjectName(fileName);
+        }
     }
 
 }

--- a/src/main/java/run/halo/alioss/FileNameUtils.java
+++ b/src/main/java/run/halo/alioss/FileNameUtils.java
@@ -1,0 +1,44 @@
+package run.halo.alioss;
+
+import com.google.common.io.Files;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public final class FileNameUtils {
+
+    private FileNameUtils() {
+    }
+
+    public static String removeFileExtension(String filename, boolean removeAllExtensions) {
+        if (filename == null || filename.isEmpty()) {
+            return filename;
+        }
+        var extPattern = "(?<!^)[.]" + (removeAllExtensions ? ".*" : "[^.]*$");
+        return filename.replaceAll(extPattern, "");
+    }
+
+    /**
+     * Append random string after file name.
+     * <pre>
+     * Case 1: halo.run -> halo-xyz.run
+     * Case 2: .run -> xyz.run
+     * Case 3: halo -> halo-xyz
+     * </pre>
+     *
+     * @param filename is name of file.
+     * @param length is for generating random string with specific length.
+     * @return File name with random string.
+     */
+    public static String randomFileName(String filename, int length) {
+        var nameWithoutExt = Files.getNameWithoutExtension(filename);
+        var ext = Files.getFileExtension(filename);
+        var random = RandomStringUtils.randomAlphabetic(length).toLowerCase();
+        if (StringUtils.isBlank(nameWithoutExt)) {
+            return random + "." + ext;
+        }
+        if (StringUtils.isBlank(ext)) {
+            return nameWithoutExt + "-" + random;
+        }
+        return nameWithoutExt + "-" + random + "." + ext;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/halo-dev/halo/issues/3337
不更新依赖了，直接复制了FileNameUtils
在有image.png的情况下再同时粘贴两张截图，期望两张都能被上传且被自动重命名。
![image](https://user-images.githubusercontent.com/28662535/220262053-497e3051-e93d-4cad-b97d-7fc84a9cdb4b.png)
![image](https://user-images.githubusercontent.com/28662535/220262092-e4f0e9f6-00ad-4626-ba03-1db25334436e.png)
```release-note
检查文件是否存在，文件存在时自动重命名
```